### PR TITLE
Update Main.php / Fix syntax errors + optimization

### DIFF
--- a/src/BackToSpawn/Main.php
+++ b/src/BackToSpawn/Main.php
@@ -11,15 +11,15 @@ use pocketmine\utils\TextFormat;
 class BackToSpawn extends PluginBase{
 
     public function onEnable(){
-        $this->getLogger()->info("[BackToSpawn] enabled")
+        $this->getLogger()->info("[BackToSpawn] enabled");
     }
     
     public function onDisable(){
-        $this->getLogger()->info("[BackToSpawn] enabled")
+        $this->getLogger()->info("[BackToSpawn] enabled");
     }
     
     public function onCommand(CommandSender $sender, Command $command, $label, array $args){
-        if(strtolower($command->getName()) === "spawn"){
+        if($command->getName() === "spawn"){
             if(!($sender instanceof Player)){
                 $sender->sendMessage(TextFormat::RED."Please run this command in game");
                 return true;


### PR DESCRIPTION
Critical syntax errors on line 14 & 22, Syntaxious. 
No need for strtolower() my friends. The output of $command->getName() is already a lower-case string because it is received from the plugin.yml, not the user input.
